### PR TITLE
Wildcard DNS Entry 

### DIFF
--- a/kubernetes/terraform/k8s_cluster/dns.tf
+++ b/kubernetes/terraform/k8s_cluster/dns.tf
@@ -19,13 +19,5 @@ resource "aws_route53_record" "k8s_record" {
   name    = "*.${terraform.workspace}.gsp.test"
   type    = "A"
   ttl     = "300"
-  records = "${aws_instance.k8s_master[*].private_ip}" # TODO: figure out how to turn an interpolation into a list.
-}
-
-resource "aws_route53_record" "k8s_registry_record" {
-  zone_id = "${aws_route53_zone.k8s_r53_zone.zone_id}"
-  name    = "registry.${terraform.workspace}.gsp.test"
-  type    = "A"
-  ttl     = "300"
-  records = ["${aws_instance.k8s_master[0].private_ip}"]
+  records = "${aws_instance.k8s_master[*].private_ip}"
 }

--- a/kubernetes/terraform/k8s_cluster/dns.tf
+++ b/kubernetes/terraform/k8s_cluster/dns.tf
@@ -14,12 +14,12 @@ resource "aws_route53_zone" "k8s_r53_zone" {
   }
 }
 
-resource "aws_route53_record" "k8s_auth_record" {
+resource "aws_route53_record" "k8s_record" {
   zone_id = "${aws_route53_zone.k8s_r53_zone.zone_id}"
-  name    = "auth.${terraform.workspace}.gsp.test"
+  name    = "*.${terraform.workspace}.gsp.test"
   type    = "A"
   ttl     = "300"
-  records = ["${aws_instance.k8s_master[0].private_ip}"] # TODO: figure out how to turn an interpolation into a list.
+  records = "${aws_instance.k8s_master[*].private_ip}" # TODO: figure out how to turn an interpolation into a list.
 }
 
 resource "aws_route53_record" "k8s_registry_record" {


### PR DESCRIPTION
Instead of adding dns records on an individual basis, we can just wildcard the entry for the domain. This makes additionally addresses clients running on the grayskull platform being able to resolve their arbitrary domains from within the cluster.