### PR TITLE
Add variable for ceph storage location

### DIFF
--- a/kubernetes/ansible/playbooks/roles/rook_ceph_role/defaults/main.yml
+++ b/kubernetes/ansible/playbooks/roles/rook_ceph_role/defaults/main.yml
@@ -6,6 +6,7 @@ ceph_namespace: "grayskull-storage"
 ceph_defaultStorage_enabled: true
 ceph_mon_count: 3
 ceph_objectstore_name: gsp-store
+ceph_data_dir: /storage/rook #/var/lib/rook
 
 subfolder: "rook-ceph-role"
 role_dir: "{{ grayskull_dir }}/{{ subfolder }}"

--- a/kubernetes/ansible/playbooks/roles/rook_ceph_role/tasks/remove.yml
+++ b/kubernetes/ansible/playbooks/roles/rook_ceph_role/tasks/remove.yml
@@ -97,7 +97,7 @@
   ignore_errors: true
   block:
   - name: Rook Ceph | Remove rook directory
-    shell: "rm -rf /var/lib/rook"
+    shell: "rm -rf {{ ceph_data_dir }}"
 
   - name: Rook Ceph | Zap disk
     shell: "sgdisk --zap-all /dev/nvme1n1"

--- a/kubernetes/ansible/playbooks/roles/rook_ceph_role/templates/rook-ceph-cluster.yml
+++ b/kubernetes/ansible/playbooks/roles/rook_ceph_role/templates/rook-ceph-cluster.yml
@@ -7,7 +7,7 @@ spec:
   cephVersion:
     image: {{ template_ceph_image }}:{{ template_ceph_image_version }}
     allowUnsupported: false
-  dataDirHostPath: /var/lib/rook
+  dataDirHostPath: {{ ceph_data_dir }}
   mon:
     count: {{ ceph_mon_count }}
     allowMultiplePerNode: false
@@ -37,4 +37,4 @@ spec:
     #deviceFilter:
     #location:
     config:
-    #- path: /var/lib/rook
+    #- path: {{ ceph_data_dir }}


### PR DESCRIPTION
Closes #76 

This PR adds a variable for the `dataDirHostPath` of rook. This is where rook keeps configuration and state data about its monitors and osds. This data can get pretty sizable and so choosing a place with enough storage for it is an option we'll need.