### PR TITLE
Cert-manager

### DIFF
--- a/kubernetes/ansible/playbooks/grayskull.yml
+++ b/kubernetes/ansible/playbooks/grayskull.yml
@@ -101,44 +101,21 @@
   - name: Setup | Update Helm repos
     command: "{{ bin_dir }}/helm repo update"
 
-  # ---- Make Certificates
-  - name: Certificate Tasks | Create grayskull/secrets directory
+  - name: Setup | Create grayskull/secrets directory
     file:
       path: "{{ grayskull_dir }}/secrets"
       state: directory
       mode: '0755'
 
-  # Create a csr for our domain
-  - name: Certificate Tasks | Create csr and copy to remote.
+  - name: Setup | Create CSR and copy to remote.
     template:
       src: csr.json.tpl
       dest: "{{ grayskull_dir }}/csr.json"
 
-# ---- Make Certs
 - hosts: kube-setup-delegate
   become: yes
   roles:
     - role: certs_role
-      vars:
-        # create a ca to sign our certs
-        task_create_ca: true
-        ca_path: "{{ grayskull_dir }}/ca"
-        ca_csrjson_src: "{{ grayskull_dir }}/csr.json"
-        # create a server, client, and chain cert
-        task_create_server: true
-        server_path: "{{ grayskull_dir }}/server"
-        server_client_path: "{{ grayskull_dir }}/client"
-        server_chain_path: "{{ grayskull_dir }}/chain"
-        # copy the certs to name them as the k8s secret expects
-        task_copy: true
-        copy_ca_path: "{{ grayskull_dir }}/cacerts.pem"
-        copy_server_key_path: "{{ grayskull_dir }}/secrets/tls.key"
-        copy_chain_path: "{{ grayskull_dir }}/secrets/tls.crt"
-
-#---- Run the service roles
-- hosts: kube-setup-delegate
-  become: yes
-  roles:
     - { role: cert_manager_role, when: (cert_manager_role_enabled | default(True)) }
     - { role: ingress_role, when: (ingress_role_enabled | default(True)) }
     - { role: dashboard_role, when: (dashboard_role_enabled | default(True)) }

--- a/kubernetes/ansible/playbooks/grayskull.yml
+++ b/kubernetes/ansible/playbooks/grayskull.yml
@@ -139,6 +139,7 @@
 - hosts: kube-setup-delegate
   become: yes
   roles:
+    - { role: cert_manager_role, when: (cert_manager_role_enabled | default(True)) }
     - { role: ingress_role, when: (ingress_role_enabled | default(True)) }
     - { role: dashboard_role, when: (dashboard_role_enabled | default(True)) }
     - { role: prometheus_role, when: (prometheus_role_enabled | default(True)) }   # must be deployed before rook-ceph

--- a/kubernetes/ansible/playbooks/remove.yml
+++ b/kubernetes/ansible/playbooks/remove.yml
@@ -46,6 +46,7 @@
     # Rook relies on prometheus when the integration is enabled, so it must be deleted first.
     - { role: rook_cassandra_role, vars: { task_modes: [ 'remove' ] }, when: (rook_cassandra_role_enabled | default(True)) }
     - { role: prometheus_role, vars: { task_modes: [ 'remove' ] }, when: (prometheus_role_enabled | default(True)) }   # must be deleted after rook-ceph
+    - { role: cert_manager_role, vars: { task_modes: [ 'remove' ] }, when: (cert_manager_role_enabled | default(True)) }
 
 # Remove helm and delete the directory.    
 - hosts: kube-setup-delegate

--- a/kubernetes/ansible/playbooks/roles/auth_role/defaults/main.yml
+++ b/kubernetes/ansible/playbooks/roles/auth_role/defaults/main.yml
@@ -3,6 +3,7 @@ task_modes:
   - install
 
 auth_namespace: grayskull-auth
+
 subfolder: auth-role
 role_dir: "{{ grayskull_dir }}/{{ subfolder }}"
 auth_secrets_dir: "{{ role_dir }}/secrets"
@@ -10,13 +11,12 @@ auth_secrets_dir: "{{ role_dir }}/secrets"
 auth_passwd_secretName: "auth-gsp-passwd"
 auth_passwd_file: "{{ auth_secrets_dir }}/password"
 
+kube_ca_path: "/etc/kubernetes/ssl"
+kube_ca_issuer_name: kube-ca-issuer
+
 helm_auth_chart_name: "{{ platform_prefix }}-keycloak"
 helm_auth_repo_url: https://codecentric.github.io/helm-charts
 helm_auth_image_name: keycloak
 helm_auth_chart_version: 4.14.2
 
-ingress_secretName: "auth-gsp-tls"
-ingress_tls_cert: "{{ auth_secrets_dir }}/tls.crt"
-ingress_tls_key: "{{ auth_secrets_dir }}/tls.key"
-
-kube_ca_path: "/etc/kubernetes/ssl"
+ingress_secretName: auth-gsp-tls

--- a/kubernetes/ansible/playbooks/roles/auth_role/tasks/install.yml
+++ b/kubernetes/ansible/playbooks/roles/auth_role/tasks/install.yml
@@ -48,6 +48,7 @@
     auth_role_templates:
       - { file: auth-namespace.yml }
       - { file: auth-configmap.yml }
+      - { file: auth-certificate.yml }
 
 - name: Authorization | Create manifests
   template:
@@ -76,71 +77,6 @@
     src: "files/secrets/password"
     dest: "{{ auth_passwd_file }}"
     mode: 0755
-
-
-# ---- Make Certs
-
-# One of the differences between kubespray and RKE is what they call their certs.
-# The next 3 tasks copy the kubespray one to the corresponding name that RKE would use.
-# This is especially prudent becasue the certs_role copies files using a naming scheme that is 
-# closer to that of RKE. 
-- name: Authorization | Check for kube-ca
-  stat:
-    path: /etc/kubernetes/ssl/kube-ca.pem
-  register: kubeca
-
-- name: Authorization | Check for other kube-ca
-  stat:
-    path: /etc/kubernetes/ssl/ca.crt
-  register: cacrt
-  when: kubeca.stat is defined and not kubeca.stat.exists
-
-- name: Authorization | Copy kube-ca
-  copy:
-    src: "/etc/kubernetes/ssl/ca.crt"
-    dest: "/etc/kubernetes/ssl/kube-ca.pem"
-    remote_src: true
-  when: cacrt.stat is defined and cacrt.stat.exists
-
-- name: Authorization | Copy kube-ca-key
-  copy:
-    src: "/etc/kubernetes/ssl/ca.key"
-    dest: "/etc/kubernetes/ssl/kube-ca-key.pem"
-    remote_src: true
-  when: cacrt.stat is defined and cacrt.stat.exists
-
-- name: Authorization | Make certs
-  import_role:
-    name: certs_role
-  vars:
-    # create a ca to sign our certs
-    ca_path: "{{ kube_ca_path }}/kube-ca"
-    ca_csrjson_src: "{{ grayskull_dir }}/csr.json"
-    # create a server, client, and chain cert
-    task_create_server: true
-    server_path: "{{ grayskull_dir }}/auth-server"
-    server_client_path: "{{ grayskull_dir }}/auth-client"
-    server_chain_path: "{{ grayskull_dir }}/auth-chain"
-    # copy the certs to name them as the k8s secret expects
-    task_copy: true
-    copy_ca_path: "{{ grayskull_dir }}/cacerts.pem"
-    copy_server_key_path: "{{ ingress_tls_key }}"
-    copy_chain_path: "{{ ingress_tls_cert }}"
-
-
-#---- Create secret
-- name: Authorization | Check for secret
-  shell: "{{ bin_dir }}/kubectl get secrets -n {{ auth_namespace }}"
-  register: auth_secret_exists
-  changed_when: false
-
-- name: Authorization | Create secret
-  shell: "{{ bin_dir }}/kubectl create secret generic {{ ingress_secretName }} --from-file {{ ingress_tls_cert }} --from-file {{ ingress_tls_key }} --from-file ca.crt={{ kube_ca_path }}/kube-ca.pem -n {{ auth_namespace }}"
-  when: "ingress_secretName not in auth_secret_exists.stdout"
-
-- name: Authorization | Create pass secret
-  shell: "{{ bin_dir }}/kubectl create secret generic {{ auth_passwd_secretName }} --from-file {{ auth_passwd_file }} -n {{ auth_namespace }}"
-  when: "auth_passwd_secretName not in auth_secret_exists.stdout"
 
 - name: Authorization | Deploy chart
   helm_chart:

--- a/kubernetes/ansible/playbooks/roles/auth_role/tasks/install.yml
+++ b/kubernetes/ansible/playbooks/roles/auth_role/tasks/install.yml
@@ -78,6 +78,15 @@
     dest: "{{ auth_passwd_file }}"
     mode: 0755
 
+- name: Authorization | Check for secret
+  shell: "{{ bin_dir }}/kubectl get secrets -n {{ auth_namespace }}"
+  register: auth_secret_exists
+  changed_when: false
+
+- name: Authorization | Create pass secret
+  shell: "{{ bin_dir }}/kubectl create secret generic {{ auth_passwd_secretName }} --from-file {{ auth_passwd_file }} -n {{ auth_namespace }}"
+  when: "auth_passwd_secretName not in auth_secret_exists.stdout"
+
 - name: Authorization | Deploy chart
   helm_chart:
     name: "{{ helm_auth_chart_name }}"

--- a/kubernetes/ansible/playbooks/roles/auth_role/tasks/install.yml
+++ b/kubernetes/ansible/playbooks/roles/auth_role/tasks/install.yml
@@ -124,8 +124,8 @@
     # copy the certs to name them as the k8s secret expects
     task_copy: true
     copy_ca_path: "{{ grayskull_dir }}/cacerts.pem"
-    copy_server_key_path: "{{ auth_secrets_dir }}/tls.key"
-    copy_chain_path: "{{ auth_secrets_dir }}/tls.crt"
+    copy_server_key_path: "{{ ingress_tls_key }}"
+    copy_chain_path: "{{ ingress_tls_cert }}"
 
 
 #---- Create secret
@@ -135,7 +135,7 @@
   changed_when: false
 
 - name: Authorization | Create secret
-  shell: "{{ bin_dir }}/kubectl create secret generic {{ ingress_secretName }} --from-file {{ auth_secrets_dir }}/tls.crt --from-file {{ auth_secrets_dir }}/tls.key --from-file ca.crt={{ kube_ca_path }}/kube-ca.pem -n {{ auth_namespace }}"
+  shell: "{{ bin_dir }}/kubectl create secret generic {{ ingress_secretName }} --from-file {{ ingress_tls_cert }} --from-file {{ ingress_tls_key }} --from-file ca.crt={{ kube_ca_path }}/kube-ca.pem -n {{ auth_namespace }}"
   when: "ingress_secretName not in auth_secret_exists.stdout"
 
 - name: Authorization | Create pass secret

--- a/kubernetes/ansible/playbooks/roles/auth_role/tasks/remove.yml
+++ b/kubernetes/ansible/playbooks/roles/auth_role/tasks/remove.yml
@@ -15,21 +15,15 @@
     chart_version: "{{ helm_auth_chart_version }}"
     state: absent
 
-
 #---- Remove secret
 - name: Authorization | Check for secret
   shell: "{{ bin_dir }}/kubectl get secrets -n {{ auth_namespace }}"
   register: auth_secret_exists
   changed_when: false
 
-- name: Authorization | Remove secret
-  shell: "{{ bin_dir }}/kubectl delete secret {{ ingress_secretName }} -n {{ auth_namespace }}"
-  when: "ingress_secretName in auth_secret_exists.stdout"
-
 - name: Authorization | Remove pass secret
   shell: "{{ bin_dir }}/kubectl delete secret {{ auth_passwd_secretName }} -n {{ auth_namespace }}"
   when: "auth_passwd_secretName in auth_secret_exists.stdout"
-
 
 #---- Remove certificate made from kubernetes CA.
 - name: Authorization | Stat secrets directory
@@ -51,6 +45,7 @@
     auth_role_templates:
       - { file: auth-configmap.yml }
       - { file: auth-namespace.yml }
+      - { file: auth-certificate.yml }
       
 - name: Authorization | Create manifests
   template:

--- a/kubernetes/ansible/playbooks/roles/auth_role/templates/auth-certificate.yml
+++ b/kubernetes/ansible/playbooks/roles/auth_role/templates/auth-certificate.yml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: auth-cert
+spec:
+  secretName: {{ ingress_secretName }}
+  issuerRef:
+    name: {{ kube_ca_issuer_name }}
+    kind: ClusterIssuer
+  dnsNames:
+    - auth.{{ grayskull_domain }}

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/defaults/main.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/defaults/main.yml
@@ -2,18 +2,16 @@ task_modes:
   - download
   - install
 
-bin_dir: "/usr/local/bin"
-
 cert_manager_namespace: grayskull-cert-manager
-
-grayskull_ca_path: "{{ grayskull_dir }}/ca"
-grayskull_ca_csrjson_src: "{{ grayskull_dir }}/csr.json"
-kube_ca_path: /etc/kubernetes/ssl
 
 grayskull_ca_issuer_name: grayskull-ca-issuer
 grayskull_ca_issuer_secret: grayskull-ca-key-pair
+grayskull_ca_path: "{{ grayskull_dir }}/ca"
+grayskull_ca_csrjson_src: "{{ grayskull_dir }}/csr.json"
+
 kube_ca_issuer_name: kube-ca-issuer
 kube_ca_issuer_secret: kube-ca-key-pair
+kube_ca_path: /etc/kubernetes/ssl
 
 helm_cert_manager_chart_name: "{{ platform_prefix }}-cert-manager"
 helm_cert_manager_repo_url: https://charts.jetstack.io

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/defaults/main.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/defaults/main.yml
@@ -1,0 +1,12 @@
+task_modes:
+  - download
+  - install
+
+bin_dir: "/usr/local/bin"
+
+cert_manager_namespace: grayskull-cert-manager
+
+helm_cert_manager_chart_name: "{{ platform_prefix }}-cert-manager"
+helm_cert_manager_repo_url: https://charts.jetstack.io
+helm_cert_manager_image_name: cert-manager
+helm_cert_manager_chart_version: v0.12.0

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/defaults/main.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/defaults/main.yml
@@ -6,6 +6,15 @@ bin_dir: "/usr/local/bin"
 
 cert_manager_namespace: grayskull-cert-manager
 
+grayskull_ca_path: "{{ grayskull_dir }}/ca"
+grayskull_ca_csrjson_src: "{{ grayskull_dir }}/csr.json"
+kube_ca_path: /etc/kubernetes/ssl
+
+grayskull_ca_issuer_name: grayskull-ca-issuer
+grayskull_ca_issuer_secret: grayskull-ca-key-pair
+kube_ca_issuer_name: kube-ca-issuer
+kube_ca_issuer_secret: kube-ca-key-pair
+
 helm_cert_manager_chart_name: "{{ platform_prefix }}-cert-manager"
 helm_cert_manager_repo_url: https://charts.jetstack.io
 helm_cert_manager_image_name: cert-manager

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/download.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/download.yml
@@ -1,0 +1,12 @@
+- name: Cert-manager | Download CRDs
+  get_url:
+    url: https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/deploy/manifests/00-crds.yaml
+    dest: "{{ grayskull_dir }}/crds.yml"
+
+- name: Cert-manager | Download chart
+  shell: "{{ bin_dir }}/helm fetch \
+    --repo {{ helm_cert_manager_repo_url }} \
+    --version {{ helm_cert_manager_chart_version }} \
+    --destination {{ grayskull_dir }} \
+    --untar \
+    {{ helm_cert_manager_image_name }}"

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/download.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/download.yml
@@ -1,4 +1,4 @@
-- name: Cert-manager | Download CRDs
+- name: Cert-manager | Download custom resource definitions
   get_url:
     url: https://raw.githubusercontent.com/jetstack/cert-manager/release-0.12/deploy/manifests/00-crds.yaml
     dest: "{{ grayskull_dir }}/crds.yml"

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/install.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/install.yml
@@ -12,14 +12,12 @@
 
 - name: Cert-manager | Apply manifests
   kube:
-    name: "{{ item.item.name }}"
     kubectl: "{{ bin_dir }}/kubectl"
-    resource: "{{ item.item.type }}"
     filename: "{{ grayskull_dir }}/{{ item.item.file }}"
     state: latest
   with_items: "{{ cert_manager_manifests.results }}"
 
-- name: Cert-manager | Apply CRDs
+- name: Cert-manager | Apply custom resource definitions
   shell: "{{ bin_dir }}/kubectl apply \
     --validate=false \
     -f {{ grayskull_dir }}/crds.yml"
@@ -32,3 +30,13 @@
     chart_src: "{{ grayskull_dir }}/{{ helm_cert_manager_image_name }}"
     chart_version: "{{ helm_cert_manager_chart_version }}"
 
+- name: Cert-manager | Template cluster issuer
+  template:
+    src: cert-manager-cluster-issuer.yml
+    dest: "{{ grayskull_dir }}/cert-manager-cluster-issuer.yml"
+
+- name: Cert-manager | Apply cluster issuer
+  kube:
+    kubectl: "{{ bin_dir }}/kubectl"
+    filename: "{{ grayskull_dir }}/cert-manager-cluster-issuer.yml"
+    state: latest

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/install.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/install.yml
@@ -90,6 +90,11 @@
   with_items: "{{ cluster_issuer_templates }}"
   register: cluster_issuer_manifests
 
+- name: Cert-manager | Wait for webhook to become available
+  shell: "{{ bin_dir }}/kubectl wait \
+    --for condition=available --timeout=300s \
+    deployment {{ helm_cert_manager_chart_name }}-webhook -n {{ cert_manager_namespace }}"
+
 - name: Cert-manager | Apply cluster issuer manifests
   kube:
     kubectl: "{{ bin_dir }}/kubectl"

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/install.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/install.yml
@@ -22,31 +22,6 @@
     chart_src: "{{ grayskull_dir }}/{{ helm_cert_manager_image_name }}"
     chart_version: "{{ helm_cert_manager_chart_version }}"
 
-- name: Cert-manager | Check for cfssl
-  stat:
-    path: "{{ bin_dir }}/cfssl"
-  register: cfssl_exists
-
-- name: Cert-manager | Check for cfssljson
-  stat:
-    path: "{{ bin_dir }}/cfssljson"
-  register: cfssljson_exists
-
-- name: Cert-manager | Install cfssl
-  block:
-    - name: Cert-manager | Download cfssl binary
-      get_url:
-        url: https://pkg.cfssl.org/R1.2/cfssl_linux-amd64
-        dest: "{{ bin_dir }}/cfssl"
-        mode: '0755'
-
-    - name: Cert-manager | Download cfssljson binary
-      get_url:
-        url: https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64
-        dest: "{{ bin_dir }}/cfssljson"
-        mode: '0755'
-  when: not cfssl_exists.stat.exists or not cfssljson_exists.stat.exists
-
 - name: Cert-manager | List secrets in namespace
   shell: "{{ bin_dir }}/kubectl get secrets -n {{ cert_manager_namespace }}"
   register: cert_manager_secrets
@@ -59,13 +34,18 @@
       register: grayskull_ca
 
     - name: Cert-manager | Create a self-signed CA
-      shell: "{{ bin_dir }}/cfssl gencert -initca {{ grayskull_ca_csrjson_src }} | {{ bin_dir }}/cfssljson -bare {{ grayskull_ca_path }}"
+      import_role:
+        name: certs_role
+      vars:
+        ca_path: "{{ grayskull_ca_path }}"
+        ca_csrjson_src: "{{ grayskull_ca_csrjson_src }}"
       when: not grayskull_ca.stat.exists
 
     - name: Cert-manager | Create grayskull CA issuer secret
       shell: "{{ bin_dir }}/kubectl create secret tls {{ grayskull_ca_issuer_secret }} --cert={{ grayskull_ca_path }}.pem --key={{ grayskull_ca_path }}-key.pem -n {{ cert_manager_namespace }}"
   when: grayskull_ca_issuer_secret not in cert_manager_secrets.stdout
 
+# This assumes kube CA exists, and will not try to create it if it doesn't
 - name: Cert-manager | Create kube CA issuer secret
   block:
     - name: Cert-manager | Check if kube CA exists

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/install.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/install.yml
@@ -1,0 +1,34 @@
+- name: Cert-manager | Templates list
+  set_fact:
+    cert_manager_templates:
+      - { name: namespace, file: cert-manager-namespace.yml, type: ns }
+
+- name: Cert-manager | Create manifests
+  template:
+    src: "{{ item.file }}"
+    dest: "{{ grayskull_dir }}/{{ item.file }}"
+  with_items: "{{ cert_manager_templates }}"
+  register: cert_manager_manifests
+
+- name: Cert-manager | Apply manifests
+  kube:
+    name: "{{ item.item.name }}"
+    kubectl: "{{ bin_dir }}/kubectl"
+    resource: "{{ item.item.type }}"
+    filename: "{{ grayskull_dir }}/{{ item.item.file }}"
+    state: latest
+  with_items: "{{ cert_manager_manifests.results }}"
+
+- name: Cert-manager | Apply CRDs
+  shell: "{{ bin_dir }}/kubectl apply \
+    --validate=false \
+    -f {{ grayskull_dir }}/crds.yml"
+
+- name: Cert-manager | Apply chart
+  helm_chart:
+    name: "{{ helm_cert_manager_chart_name }}"
+    namespace: "{{ cert_manager_namespace }}"
+    bin_dir: "{{ bin_dir }}"
+    chart_src: "{{ grayskull_dir }}/{{ helm_cert_manager_image_name }}"
+    chart_version: "{{ helm_cert_manager_chart_version }}"
+

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/install.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/install.yml
@@ -1,21 +1,13 @@
-- name: Cert-manager | Templates list
-  set_fact:
-    cert_manager_templates:
-      - { name: namespace, file: cert-manager-namespace.yml, type: ns }
-
-- name: Cert-manager | Create manifests
+- name: Cert-manager | Template namespace manifest
   template:
-    src: "{{ item.file }}"
-    dest: "{{ grayskull_dir }}/{{ item.file }}"
-  with_items: "{{ cert_manager_templates }}"
-  register: cert_manager_manifests
+    src: cert-manager-namespace.yml
+    dest: "{{ grayskull_dir }}/cert-manager-namespace.yml"
 
-- name: Cert-manager | Apply manifests
+- name: Cert-manager | Create namespace manifest
   kube:
     kubectl: "{{ bin_dir }}/kubectl"
-    filename: "{{ grayskull_dir }}/{{ item.item.file }}"
+    filename: "{{ grayskull_dir }}/cert-manager-namespace.yml"
     state: latest
-  with_items: "{{ cert_manager_manifests.results }}"
 
 - name: Cert-manager | Apply custom resource definitions
   shell: "{{ bin_dir }}/kubectl apply \
@@ -30,13 +22,22 @@
     chart_src: "{{ grayskull_dir }}/{{ helm_cert_manager_image_name }}"
     chart_version: "{{ helm_cert_manager_chart_version }}"
 
-- name: Cert-manager | Template cluster issuer
-  template:
-    src: cert-manager-cluster-issuer.yml
-    dest: "{{ grayskull_dir }}/cert-manager-cluster-issuer.yml"
+- name: Cert-manager | List cluster issuer manifests
+  set_fact:
+    cluster_issuer_templates:
+      - { file: cert-manager-grayskull-issuer.yml }
+      - { file: cert-manager-kube-issuer.yml }
 
-- name: Cert-manager | Apply cluster issuer
+- name: Cert-manager | Template cluster issuer manifests
+  template:
+    src: "{{ item.file }}"
+    dest: "{{ grayskull_dir }}/{{ item.file }}"
+  with_items: "{{ cluster_issuer_templates }}"
+  register: cluster_issuer_manifests
+
+- name: Cert-manager | Apply cluster issuer manifests
   kube:
     kubectl: "{{ bin_dir }}/kubectl"
-    filename: "{{ grayskull_dir }}/cert-manager-cluster-issuer.yml"
+    filename: "{{ grayskull_dir }}/{{ item.item.file }}"
     state: latest
+  with_items: "{{ cluster_issuer_manifests.results }}"

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/install.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/install.yml
@@ -22,6 +22,81 @@
     chart_src: "{{ grayskull_dir }}/{{ helm_cert_manager_image_name }}"
     chart_version: "{{ helm_cert_manager_chart_version }}"
 
+- name: Cert-manager | Check for cfssl
+  stat:
+    path: "{{ bin_dir }}/cfssl"
+  register: cfssl_exists
+
+- name: Cert-manager | Check for cfssljson
+  stat:
+    path: "{{ bin_dir }}/cfssljson"
+  register: cfssljson_exists
+
+- name: Cert-manager | Install cfssl
+  block:
+    - name: Cert-manager | Download cfssl binary
+      get_url:
+        url: https://pkg.cfssl.org/R1.2/cfssl_linux-amd64
+        dest: "{{ bin_dir }}/cfssl"
+        mode: '0755'
+
+    - name: Cert-manager | Download cfssljson binary
+      get_url:
+        url: https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64
+        dest: "{{ bin_dir }}/cfssljson"
+        mode: '0755'
+  when: not cfssl_exists.stat.exists or not cfssljson_exists.stat.exists
+
+- name: Cert-manager | List secrets in namespace
+  shell: "{{ bin_dir }}/kubectl get secrets -n {{ cert_manager_namespace }}"
+  register: cert_manager_secrets
+
+- name: Cert-manager | Create grayskull CA issuer secret
+  block:
+    - name: Cert-manager | Check if grayskull CA exists
+      stat:
+        path: "{{ grayskull_ca_path }}.pem"
+      register: grayskull_ca
+
+    - name: Cert-manager | Create a self-signed CA
+      shell: "{{ bin_dir }}/cfssl gencert -initca {{ grayskull_ca_csrjson_src }} | {{ bin_dir }}/cfssljson -bare {{ grayskull_ca_path }}"
+      when: not grayskull_ca.stat.exists
+
+    - name: Cert-manager | Create grayskull CA issuer secret
+      shell: "{{ bin_dir }}/kubectl create secret tls {{ grayskull_ca_issuer_secret }} --cert={{ grayskull_ca_path }}.pem --key={{ grayskull_ca_path }}-key.pem -n {{ cert_manager_namespace }}"
+  when: grayskull_ca_issuer_secret not in cert_manager_secrets.stdout
+
+- name: Cert-manager | Create kube CA issuer secret
+  block:
+    - name: Cert-manager | Check if kube CA exists
+      stat:
+        path: "{{ kube_ca_path }}/kube-ca.pem"
+      register: kube_ca
+
+    - name: Cert-manager | Check if alternate CA exists
+      stat:
+        path: "{{ kube_ca_path }}/ca.crt"
+      register: alt_ca
+      when: not kube_ca.stat.exists
+
+    - name: Cert-manager | Rename kube CA certificate
+      copy:
+        src: "{{ kube_ca_path }}/ca.crt"
+        dest: "{{ kube_ca_path }}/kube-ca.pem"
+        remote_src: true
+      when: alt_ca.stat is defined and alt_ca.stat.exists
+
+    - name: Cert-manager | Rename kube CA key
+      copy:
+        src: "{{ kube_ca_path }}/ca.key"
+        dest: "{{ kube_ca_path }}/kube-ca-key.pem"
+        remote_src: true
+      when: alt_ca.stat is defined and alt_ca.stat.exists
+
+    - name: Cert-manager | Create kube CA issuer secret
+      shell: "{{ bin_dir }}/kubectl create secret tls {{ kube_ca_issuer_secret }} --cert={{ kube_ca_path }}/kube-ca.pem --key={{ kube_ca_path }}/kube-ca-key.pem -n {{ cert_manager_namespace }}"
+  when: kube_ca_issuer_secret not in cert_manager_secrets.stdout
+
 - name: Cert-manager | List cluster issuer manifests
   set_fact:
     cluster_issuer_templates:

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/main.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/main.yml
@@ -1,0 +1,5 @@
+- name: Cert-manager | Import tasks for install or remove
+  include_tasks: "{{ line_item }}.yml"
+  with_items: "{{ task_modes }}"
+  loop_control:
+    loop_var: line_item

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/remove.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/remove.yml
@@ -1,0 +1,33 @@
+- name: Cert-manager | Remove chart
+  helm_chart:
+    name: "{{ helm_cert_manager_chart_name }}"
+    namespace: "{{ cert_manager_namespace }}"
+    bin_dir: "{{ bin_dir }}"
+    chart_src: "{{ grayskull_dir }}/{{ helm_cert_manager_image_name }}"
+    chart_version: "{{ helm_cert_manager_chart_version }}"
+    state: absent
+
+- name: Cert-manager | Remove CRDs
+  kube:
+    kubectl: "{{ bin_dir }}/kubectl"
+    filename: "{{ grayskull_dir }}/crds.yml"
+    state: absent
+
+- name: Cert-manager | Templates list
+  set_fact:
+    cert_manager_templates:
+      - { name: namespace, file: cert-manager-namespace.yml, type: ns }
+
+- name: Cert-manager | Create manifests
+  template:
+    src: "{{ item.file }}"
+    dest: "{{ grayskull_dir }}/{{ item.file }}"
+  with_items: "{{ cert_manager_templates }}"
+  register: cert_manager_manifests
+
+- name: Cert-manager | Remove manifest products
+  kube:
+    kubectl: "{{ bin_dir }}/kubectl"
+    filename: "{{ grayskull_dir}}/{{ item.item.file }}"
+    state: absent
+  with_items: "{{ cert_manager_manifests.results }}"

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/remove.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/remove.yml
@@ -1,8 +1,22 @@
-- name: Cert-manager | Remove cluster issuer
+- name: Cert-manager | List cluster issuer manifests
+  set_fact:
+    cluster_issuer_templates:
+      - { file: cert-manager-grayskull-issuer.yml }
+      - { file: cert-manager-kube-issuer.yml }
+
+- name: Cert-manager | Template cluster issuer manifests
+  template:
+    src: "{{ item.file }}"
+    dest: "{{ grayskull_dir }}/{{ item.file }}"
+  with_items: "{{ cluster_issuer_templates }}"
+  register: cluster_issuer_manifests
+
+- name: Cert-manager | Remove cluster issuer manifests
   kube:
     kubectl: "{{ bin_dir }}/kubectl"
-    filename: "{{ grayskull_dir }}/cert-manager-cluster-issuer"
+    filename: "{{ grayskull_dir }}/{{ item.item.file }}"
     state: absent
+  with_items: "{{ cluster_issuer_manifests.results }}"
 
 - name: Cert-manager | Remove chart
   helm_chart:
@@ -19,21 +33,13 @@
     filename: "{{ grayskull_dir }}/crds.yml"
     state: absent
 
-- name: Cert-manager | Templates list
-  set_fact:
-    cert_manager_templates:
-      - { name: namespace, file: cert-manager-namespace.yml, type: ns }
-
-- name: Cert-manager | Create manifests
+- name: Cert-manager | Template namespace manifest
   template:
-    src: "{{ item.file }}"
-    dest: "{{ grayskull_dir }}/{{ item.file }}"
-  with_items: "{{ cert_manager_templates }}"
-  register: cert_manager_manifests
+    src: cert-manager-namespace.yml
+    dest: "{{ grayskull_dir }}/cert-manager-namespace.yml"
 
-- name: Cert-manager | Remove manifest products
+- name: Cert-manager | Delete namespace manifest
   kube:
     kubectl: "{{ bin_dir }}/kubectl"
-    filename: "{{ grayskull_dir}}/{{ item.item.file }}"
+    filename: "{{ grayskull_dir }}/cert-manager-namespace.yml"
     state: absent
-  with_items: "{{ cert_manager_manifests.results }}"

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/remove.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/remove.yml
@@ -1,3 +1,9 @@
+- name: Cert-manager | Remove cluster issuer
+  kube:
+    kubectl: "{{ bin_dir }}/kubectl"
+    filename: "{{ grayskull_dir }}/cert-manager-cluster-issuer"
+    state: absent
+
 - name: Cert-manager | Remove chart
   helm_chart:
     name: "{{ helm_cert_manager_chart_name }}"
@@ -7,7 +13,7 @@
     chart_version: "{{ helm_cert_manager_chart_version }}"
     state: absent
 
-- name: Cert-manager | Remove CRDs
+- name: Cert-manager | Remove custom resource definitions
   kube:
     kubectl: "{{ bin_dir }}/kubectl"
     filename: "{{ grayskull_dir }}/crds.yml"

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/remove.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/tasks/remove.yml
@@ -18,6 +18,17 @@
     state: absent
   with_items: "{{ cluster_issuer_manifests.results }}"
 
+- name: Cert-manager | Remove cluster issuer secrets
+  kube:
+    kubectl: "{{ bin_dir }}/kubectl"
+    name: "{{ item }}"
+    namespace: "{{ cert_manager_namespace }}"
+    resource: secret
+    state: absent
+  loop:
+    - "{{ grayskull_ca_issuer_secret }}"
+    - "{{ kube_ca_issuer_secret }}"
+
 - name: Cert-manager | Remove chart
   helm_chart:
     name: "{{ helm_cert_manager_chart_name }}"

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/templates/cert-manager-grayskull-issuer.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/templates/cert-manager-grayskull-issuer.yml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: {{ grayskull_ca_issuer_name }}
+spec:
+  ca:
+    secretName: {{ grayskull_ca_issuer_secret }}

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/templates/cert-manager-kube-issuer.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/templates/cert-manager-kube-issuer.yml
@@ -1,0 +1,7 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: ClusterIssuer
+metadata:
+  name: {{ kube_ca_issuer_name }}
+spec:
+  ca:
+    secretName: {{ kube_ca_issuer_secret }}

--- a/kubernetes/ansible/playbooks/roles/cert_manager_role/templates/cert-manager-namespace.yml
+++ b/kubernetes/ansible/playbooks/roles/cert_manager_role/templates/cert-manager-namespace.yml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ cert_manager_namespace }}
+  labels:
+    name: {{ cert_manager_namespace }}
+    certmanager.k8s.io/disable-validation: "true"

--- a/kubernetes/ansible/playbooks/roles/certs_role/defaults/main.yml
+++ b/kubernetes/ansible/playbooks/roles/certs_role/defaults/main.yml
@@ -1,24 +1,8 @@
-#  You must explicitly define each variable for each role. The default value doesn't matter if its overridden anywhere.
 task_modes:
   - install
 
-bin_dir: /usr/local/bin
+ca_path: "{{ grayskull_dir }}/ca"
+ca_csrjson_src: "{{ grayskull_dir }}/csr.json"
 
-task_create_ca: false
-ca_path: ca   # for dest dont include the file extension
-ca_csrjson_src: csr.json
-
-task_create_server: false
-server_path: server   # for dest dont include the file extension
-server_client_path: client
-server_chain_path: chain
-
-task_copy: false
-copy_ca_path: cacerts.pem
-copy_server_key_path: tls.key
-copy_chain_path: tls.crt
-
-task_rke_csrs: false
-rke_inv_path: ../inventory/rke_gray.yml
-rke_results_path: certs
-rke_csr_path: csr
+cfssl_download_path: https://pkg.cfssl.org/R1.2/cfssl_linux-amd64
+cfssljson_download_path: https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64

--- a/kubernetes/ansible/playbooks/roles/certs_role/tasks/install.yml
+++ b/kubernetes/ansible/playbooks/roles/certs_role/tasks/install.yml
@@ -1,161 +1,35 @@
----
-# ---- Download cfssl and cfssljson
-- name: Certificates | Check for cfssl
-  stat: 
-    path: "{{ bin_dir }}/cfssl"
-  register: cfssl_exists
+- name: Certificates | Check if CA exists
+  stat:
+    path: "{{ ca_path }}.pem"
+  register: ca
 
-- name: Certificates | Check for cfssl
-  stat: 
-    path: "{{ bin_dir }}/cfssljson"
-  register: cfssljson_exists
-
-- name: Install cfssl
+- name: Certificates | Create a self-signed CA
   block:
-  - name: Certificates | Download cfssl binary
-    get_url: 
-      url: https://pkg.cfssl.org/R1.2/cfssl_linux-amd64
-      dest: "{{ bin_dir }}/cfssl"
-      mode: '0755'
+    - name: Certificates | Check for cfssl
+      stat:
+        path: "{{ bin_dir }}/cfssl"
+      register: cfssl
 
-  - name: Certificates | Download cfssljson binary
-    get_url: 
-      url: https://pkg.cfssl.org/R1.2/cfssljson_linux-amd64
-      dest: "{{ bin_dir }}/cfssljson"
-      mode: '0755'
-  when: cfssl_exists.stat.exists == false or cfssljson_exists.stat.exists == false
+    - name: Certificates | Check for cfssljson
+      stat:
+        path: "{{ bin_dir }}/cfssljson"
+      register: cfssljson
 
+    - name: Certificates | Install cfssl and cfssljson
+      block:
+        - name: Certificates | Download cfssl binary
+          get_url:
+            url: "{{ cfssl_download_path }}"
+            dest: "{{ bin_dir }}/cfssl"
+            mode: '0755'
 
-# ---- Generate a CA, if one does not exist
+        - name: Certificates | Download cfssljson binary
+          get_url:
+            url: "{{ cfssljson_download_path }}"
+            dest: "{{ bin_dir }}/cfssljson"
+            mode: '0755'
+      when: not cfssl.stat.exists or not cfssljson.stat.exists
 
-- name: Generate CA
-  block:
-  - name: Certificates | Check if ca exist
-    stat: 
-      path: "{{ ca_path }}.pem"
-    register: ca_exists
-
-  - name: Certificate Tasks | Create a self-signed CA
-    shell: "{{ bin_dir }}/cfssl genkey -initca {{ ca_csrjson_src }} | {{ bin_dir }}/cfssljson -bare {{ ca_path }}"
-    when: ca_exists.stat.exists == false
-  when: task_create_ca == true
-
-# ---- Generate intermediate CA 
-# TODO: make this task
-
-# ---- Generate server and chain
-
-- name: Certificate | Check if chain
-  stat: 
-    path: "{{ server_chain_path }}.pem"
-  register: chain_exists
-
-- name: Certificates | Generate Server and Chain
-  block:
-  - name: Certificate Tasks | Create a server cert
-    shell: "{{ bin_dir }}/cfssl gencert -ca {{ ca_path }}.pem -ca-key {{ ca_path }}-key.pem {{ ca_csrjson_src }} | {{ bin_dir }}/cfssljson -bare {{ server_path }}"
-    when: chain_exists.stat.exists == false
-
-  - name: Certificate Tasks | Create a client cert
-    shell: "{{ bin_dir }}/cfssl gencert -ca {{ ca_path }}.pem -ca-key {{ ca_path }}-key.pem -profile=client {{ ca_csrjson_src }} | {{ bin_dir }}/cfssljson -bare {{ server_client_path }}"
-    when: chain_exists.stat.exists == false
-
-  - name: Certificate Tasks | create chain
-    shell: "cat {{ server_path }}.pem {{ ca_path }}.pem > {{ server_chain_path }}.pem"
-    when: chain_exists.stat.exists == false
-  when: task_create_server == true
-
-# ---- Copy files
-# task for optional copying or renaming of files 
-
-- name: Certificates | Copy files
-  block:
-  - name: Certificates | Set Certs
-    set_fact:
-      certs_to_copy:
-        - { src: "{{ ca_path }}", dest: "{{ copy_ca_path }}" }
-        - { src: "{{ server_path }}-key", dest: "{{ copy_server_key_path }}" }
-        - { src: "{{ server_chain_path }}", dest: "{{ copy_chain_path }}" }
-
-  - name: Certificates | Check if local vs remote copy
-    local_action: stat path="{{ ca_path }}.pem"
-    register: localca
-    become: no
-
-  - name: Certificates | Copy from local
-    block:
-    - name: Certificate Tasks | Rename Files
-      copy:
-        src: "{{ item.src }}.pem"
-        dest: "{{ item.dest }}"
-      with_items: "{{ certs_to_copy }}"
-    when: localca.stat is defined and localca.stat.exists
-  
-  - name: Certificates | Copy from remote
-    block:
-    - name: Certificate Tasks | Remote Rename Files
-      copy:
-        src: "{{ item.src }}.pem"
-        dest: "{{ item.dest }}"
-        remote_src: true
-      with_items: "{{ certs_to_copy }}"
-    when: localca.stat is defined and not localca.stat.exists
-  when: task_copy == true
-
-# ---- Generate RKE CSRs and sign
-
-- name: Certificates | RKE files
-  block:
-
-  - name: Certificates | Make result dir
-    file:
-      dest: "{{ rke_results_path }}"
-      state: directory
-      mode: "0755"
-
-  - name: Certificates | Make csr dir
-    file:
-      dest: "{{ rke_results_path }}/{{ rke_csr_path }}"
-      state: directory
-      mode: "0755"
-
-  - name: Certificates | Generate CSRs
-    shell: "rke cert generate-csr --config {{ rke_inv_path }} --cert-dir {{ rke_results_path }}/{{ rke_csr_path }}"
-
-  - name: Certificates | fetch csrs and keys
-    set_fact:
-      csrs: "{{ query('fileglob', '{{ rke_results_path }}/{{ rke_csr_path }}/*-csr.pem') | sort }}"
-      keys: "{{ query('fileglob', '{{ rke_results_path }}/{{ rke_csr_path }}/*-key.pem') | sort }}"
-
-  - name: Certificates | make certs
-    shell: "{{ bin_dir }}/cfssl sign -ca {{ ca_path }}.pem -ca-key {{ ca_path }}-key.pem {{ item }} | {{ bin_dir }}/cfssljson -bare {{ item | replace('-csr.pem', '') }}"
-    loop: "{{ csrs }}" #iterate over the csrs
-
-  - name: Certificates | copy CA to csrs folder
-    copy:
-      src: "{{ ca_path }}.pem"
-      dest: "{{ rke_results_path }}/{{ rke_csr_path }}/kube-ca.pem"
-
-  - name: Certificates | copy CA to csrs folder
-    copy:
-      src: "{{ ca_path }}.pem"
-      dest: "{{ rke_results_path }}/{{ rke_csr_path }}/kube-apiserver-requestheader-ca.pem"
-
-  - name: Certificates | copy CA to csrs folder
-    copy:
-      src: "{{ ca_path }}-key.pem"
-      dest: "{{ rke_results_path }}/{{ rke_csr_path }}/kube-apiserver-requestheader-ca-key.pem"
-
-  - name: Certificates | copy CA csr.json to csrs folder
-    copy:
-      src: "{{ ca_csrjson_src }}"
-      dest: "{{ rke_results_path }}/{{ rke_csr_path }}/kube-service-account-token.json"
-
-  - name: Certificates | generate service account keys
-    shell: "{{ bin_dir }}/cfssl genkey {{ rke_results_path }}/{{ rke_csr_path }}/kube-service-account-token.json | {{ bin_dir }}/cfssljson --bare {{ rke_results_path }}/{{ rke_csr_path }}/kube-service-account-token"
-
-  - name: Certificates | make service token key
-    shell: "{{ bin_dir }}/cfssl sign -ca {{ ca_path }}.pem -ca-key {{ ca_path }}-key.pem {{ rke_results_path }}/{{ rke_csr_path }}/kube-service-account-token.csr | {{ bin_dir }}/cfssljson -bare {{ rke_results_path }}/{{ rke_csr_path }}/kube-service-account-token }}"
-  when: task_rke_csrs == true
-
-#TODO cleanup csr's and csr.pem's and copy produced certs and keys to corresponding directory.
+    - name: Certificates | Create a self-signed CA
+      shell: "{{ bin_dir }}/cfssl gencert -initca {{ ca_csrjson_src }} | {{ bin_dir }}/cfssljson -bare {{ ca_path }}"
+  when: not ca.stat.exists

--- a/kubernetes/ansible/playbooks/roles/certs_role/tasks/main.yml
+++ b/kubernetes/ansible/playbooks/roles/certs_role/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: Ion | Run tasks
+- name: Certificates | Run tasks
   include_tasks: "{{ line_item }}.yml"
   with_items: "{{ task_modes }}"
   loop_control:

--- a/kubernetes/ansible/playbooks/roles/dashboard_role/defaults/main.yml
+++ b/kubernetes/ansible/playbooks/roles/dashboard_role/defaults/main.yml
@@ -4,6 +4,9 @@ task_modes:
 subfolder: dashboard-role
 role_dir: "{{ grayskull_dir }}/{{ subfolder }}"
 
+grayskull_ca_issuer_name: grayskull-ca-issuer
+
+
 ingress_url: "dash.{{ grayskull_domain }}"
 ingress_secretName: "dashboard-gsp-tls"
 ingress_path: "/"

--- a/kubernetes/ansible/playbooks/roles/dashboard_role/defaults/main.yml
+++ b/kubernetes/ansible/playbooks/roles/dashboard_role/defaults/main.yml
@@ -10,5 +10,3 @@ grayskull_ca_issuer_name: grayskull-ca-issuer
 ingress_url: "dash.{{ grayskull_domain }}"
 ingress_secretName: "dashboard-gsp-tls"
 ingress_path: "/"
-ingress_tls_cert: "{{ grayskull_dir }}/secrets/tls.crt"
-ingress_tls_key: "{{ grayskull_dir }}/secrets/tls.key"

--- a/kubernetes/ansible/playbooks/roles/dashboard_role/tasks/install.yml
+++ b/kubernetes/ansible/playbooks/roles/dashboard_role/tasks/install.yml
@@ -1,15 +1,4 @@
 ---
-#---- Create secret
-- name: Dashboard | Check for secret
-  shell: "{{ bin_dir }}/kubectl get secrets -n kube-system"
-  register: dashboard_secret_exists
-  changed_when: false
-
-- name: Dashboard | Create secret
-  shell: "{{ bin_dir }}/kubectl create secret generic {{ ingress_secretName }} --from-file {{ ingress_tls_cert }} --from-file {{ ingress_tls_key }} -n kube-system"
-  when: "ingress_secretName not in dashboard_secret_exists.stdout"
-
-
 #---- Template and apply manifests
 - name: Dashboard | Templates list
   set_fact:
@@ -18,6 +7,7 @@
       - { file: dashboard-service-account.yml }
       - { file: dashboard-rolebinding.yml }
       - { file: dashboard-deployment.yml }
+      - { file: dashboard-certificate.yml }
 
 - name: Dashboard | Create subfolder
   file:

--- a/kubernetes/ansible/playbooks/roles/dashboard_role/tasks/remove.yml
+++ b/kubernetes/ansible/playbooks/roles/dashboard_role/tasks/remove.yml
@@ -6,12 +6,14 @@
       - { file: dashboard-service-account.yml }
       - { file: dashboard-rolebinding.yml }
       - { file: dashboard-deployment.yml }
+      - { file: dashboard-certificate.yml }
 
 - name: Dashboard | Create subfolder
   file:
     path: "{{ role_dir }}"
     state: directory
     mode: '0755'
+
 
 - name: Dashboard | Create manifests
   template:
@@ -33,12 +35,3 @@
     path: "{{ role_dir }}"
     state: absent
 
-#---- Delete secret
-- name: Dashboard | Check for secret
-  shell: "{{ bin_dir }}/kubectl get secrets -n kube-system"
-  register: dashboard_secret_exists
-  changed_when: false
-
-- name: Dashboard | Remove secret
-  shell: "{{ bin_dir }}/kubectl delete secret {{ ingress_secretName }} -n kube-system"
-  when: "ingress_secretName in dashboard_secret_exists.stdout"

--- a/kubernetes/ansible/playbooks/roles/dashboard_role/templates/dashboard-certificate.yml
+++ b/kubernetes/ansible/playbooks/roles/dashboard_role/templates/dashboard-certificate.yml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: dash-cert
+spec:
+  secretName: {{ ingress_secretName }}
+  issuerRef:
+    name: {{ grayskull_ca_issuer_name }}
+    kind: ClusterIssuer
+  dnsNames:
+    - dash.{{ grayskull_domain }}

--- a/kubernetes/ansible/playbooks/roles/elk_role/defaults/main.yml
+++ b/kubernetes/ansible/playbooks/roles/elk_role/defaults/main.yml
@@ -3,12 +3,11 @@ task_modes:
   - install
 
 elk_namespace: grayskull-logs
+
 subfolder: elk-role
 role_dir: "{{ grayskull_dir }}/{{ subfolder }}"
 
-ingress_secretName: "elk-gsp-tls"
-ingress_tls_cert: "{{ grayskull_dir }}/secrets/tls.crt"
-ingress_tls_key: "{{ grayskull_dir }}/secrets/tls.key"
+grayskull_ca_issuer_name: grayskull-ca-issuer
 
 helm_elasticsearch_chart_name: "{{ platform_prefix }}-elasticsearch"
 helm_elasticsearch_repo_url: https://helm.elastic.co
@@ -26,3 +25,5 @@ helm_fluentd_chart_name: "{{ platform_prefix }}-fluentd"
 helm_fluentd_chart_type: stable
 helm_fluentd_image_name: fluentd
 helm_fluentd_chart_version: 1.10.0
+
+ingress_secretName: "elk-gsp-tls"

--- a/kubernetes/ansible/playbooks/roles/elk_role/tasks/install.yml
+++ b/kubernetes/ansible/playbooks/roles/elk_role/tasks/install.yml
@@ -23,6 +23,7 @@
   set_fact:
     elk_role_templates:
       - { name: namespace, file: elk-namespace.yml, type: ns }
+      - { name: certificate, file: elk-certificate.yml, type: certificate }
 
 - name: ELK | Create manifests
   template:
@@ -39,17 +40,6 @@
     filename: "{{ role_dir }}/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ elk_role_manifests.results }}"
-
-
-#---- Create secret
-- name: ELK | Check for secret
-  shell: "{{ bin_dir }}/kubectl get secrets -n {{ elk_namespace }}"
-  register: elk_secret_exists
-  changed_when: false
-
-- name: ELK | Create secret
-  shell: "{{ bin_dir }}/kubectl create secret generic {{ ingress_secretName }} --from-file {{ ingress_tls_cert }} --from-file {{ ingress_tls_key }} -n {{ elk_namespace }}"
-  when: "ingress_secretName not in elk_secret_exists.stdout"
 
 - name: ELK | Deploy Elasticsearch chart
   helm_chart:

--- a/kubernetes/ansible/playbooks/roles/elk_role/tasks/install.yml
+++ b/kubernetes/ansible/playbooks/roles/elk_role/tasks/install.yml
@@ -22,8 +22,8 @@
 - name: ELK | Templates list
   set_fact:
     elk_role_templates:
-      - { name: namespace, file: elk-namespace.yml, type: ns }
-      - { name: certificate, file: elk-certificate.yml, type: certificate }
+      - { file: elk-namespace.yml }
+      - { file: elk-certificate.yml }
 
 - name: ELK | Create manifests
   template:

--- a/kubernetes/ansible/playbooks/roles/elk_role/tasks/remove.yml
+++ b/kubernetes/ansible/playbooks/roles/elk_role/tasks/remove.yml
@@ -46,6 +46,7 @@
   set_fact:
     elk_role_templates:
       - { file: elk-namespace.yml }
+      - { file: elk-certificate.yml }
 
 - name: ELK | Create manifests
   template:

--- a/kubernetes/ansible/playbooks/roles/elk_role/templates/elk-certificate.yml
+++ b/kubernetes/ansible/playbooks/roles/elk_role/templates/elk-certificate.yml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: elk-cert
+spec:
+  secretName: {{ ingress_secretName }}
+  issuerRef:
+    name: {{ grayskull_ca_issuer_name }}
+    kind: ClusterIssuer
+  dnsNames:
+    - kibana.{{ grayskull_domain }}

--- a/kubernetes/ansible/playbooks/roles/prometheus_role/defaults/main.yml
+++ b/kubernetes/ansible/playbooks/roles/prometheus_role/defaults/main.yml
@@ -6,11 +6,11 @@ prometheus_namespace: kube-system
 subfolder: prometheus-role
 role_dir: "{{ grayskull_dir }}/{{ subfolder }}"
 
+grayskull_ca_issuer_name: grayskull-ca-issuer
+
 helm_prometheus_chart_name: "{{ platform_prefix }}-prometheus"
 helm_prometheus_chart_type: stable
 helm_prometheus_image_name: prometheus-operator
 helm_prometheus_chart_version: 5.12.3
 
 ingress_secretName: "prom-gsp-tls"
-ingress_tls_cert: "{{ grayskull_dir }}/secrets/tls.crt"
-ingress_tls_key: "{{ grayskull_dir }}/secrets/tls.key"

--- a/kubernetes/ansible/playbooks/roles/prometheus_role/tasks/install.yml
+++ b/kubernetes/ansible/playbooks/roles/prometheus_role/tasks/install.yml
@@ -4,6 +4,7 @@
     prometheus_role_templates:
       - { file: prometheus-namespace.yml }
       - { file: prometheus-crd-clusterrole.yml }
+      - { file: prometheus-certificate.yml }
 
 - name: Prometheus | Create subfolder
   file:
@@ -31,17 +32,6 @@
     filename: "{{ role_dir }}/{{ item.item.file }}"
     state: "latest"
   with_items: "{{ prometheus_role_manifests.results }}"
-
-
-#---- Create secret
-- name: Prometheus | Check for secret
-  shell: "{{ bin_dir }}/kubectl get secrets -n {{ prometheus_namespace }}"
-  register: prometheus_secret_exists
-  changed_when: false
-
-- name: Prometheus | Create secret
-  shell: "{{ bin_dir }}/kubectl create secret generic {{ ingress_secretName }} --from-file {{ ingress_tls_cert }} --from-file {{ ingress_tls_key }} -n {{ prometheus_namespace }}"
-  when: "ingress_secretName not in prometheus_secret_exists.stdout"
 
 - name: Prometheus | Deploy chart
   helm_chart:

--- a/kubernetes/ansible/playbooks/roles/prometheus_role/tasks/remove.yml
+++ b/kubernetes/ansible/playbooks/roles/prometheus_role/tasks/remove.yml
@@ -1,13 +1,3 @@
-#---- Remove secret
-- name: Prometheus | Check for secret
-  shell: "{{ bin_dir }}/kubectl get secrets -n {{ prometheus_namespace }}"
-  register: prometheus_secret_exists
-  changed_when: false
-
-- name: Prometheus | Remove secret
-  shell: "{{ bin_dir }}/kubectl delete secret {{ ingress_secretName }} -n {{ prometheus_namespace }}"
-  when: "ingress_secretName in prometheus_secret_exists.stdout"
-
 - name: Prometheus | Remove chart
   helm_chart:
     name: "{{ helm_prometheus_chart_name }}"
@@ -57,6 +47,7 @@
     prometheus_role_templates:
       # - { file: prometheus-namespace.yml }
       - { file: prometheus-crd-clusterrole.yml }
+      - { file: prometheus-certificate.yml }
 
 - name: Prometheus | Create manifests
   template:

--- a/kubernetes/ansible/playbooks/roles/prometheus_role/templates/prometheus-certificate.yml
+++ b/kubernetes/ansible/playbooks/roles/prometheus_role/templates/prometheus-certificate.yml
@@ -1,0 +1,13 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: prom-cert
+spec:
+  secretName: {{ ingress_secretName }}
+  issuerRef:
+    name: {{ grayskull_ca_issuer_name }}
+    kind: ClusterIssuer
+  dnsNames:
+    - prom.{{ grayskull_domain }}
+    - graph.{{ grayskull_domain }}
+    - alert.{{ grayskull_domain }}

--- a/kubernetes/ansible/playbooks/roles/registry_role/defaults/main.yml
+++ b/kubernetes/ansible/playbooks/roles/registry_role/defaults/main.yml
@@ -6,6 +6,8 @@ registry_namespace: grayskull-registry
 subfolder: registry-role
 role_dir: "{{ grayskull_dir }}/{{ subfolder }}"
 
+grayskull_ca_issuer_name: grayskull-ca-issuer
+
 ca_path_remote_src: "{{ grayskull_dir }}/ca.pem"
 ca_path_dest: "/etc/docker/certs.d/{{ ingress_host }}"
 
@@ -18,7 +20,4 @@ helm_registry_image_name: harbor
 helm_registry_chart_version: 1.2.0
 
 ingress_secretName: "reg-gsp-tls"
-ingress_tls_cert: "{{ grayskull_dir }}/secrets/tls.crt"
-ingress_tls_key: "{{ grayskull_dir }}/secrets/tls.key"
 ingress_host: "registry.{{ grayskull_domain }}"
-

--- a/kubernetes/ansible/playbooks/roles/registry_role/tasks/install.yml
+++ b/kubernetes/ansible/playbooks/roles/registry_role/tasks/install.yml
@@ -77,6 +77,7 @@
     set_fact:
       registry_role_templates:
         - { file: registry-namespace.yml }
+        - { file: registry-certificate.yml }
 
   - name: Registry | Template values file
     template:
@@ -125,16 +126,6 @@
   when:
     - inventory_hostname == groups['kube-setup-delegate'][0]
   block:
-  #---- Create secret
-  - name: Registry | Check for secret
-    shell: "{{ bin_dir }}/kubectl get secrets -n {{ registry_namespace }}"
-    register: registry_secret_exists
-    changed_when: false
-
-  - name: Registry | Create secret
-    shell: "{{ bin_dir }}/kubectl create secret generic {{ ingress_secretName }} --from-file {{ ingress_tls_cert }} --from-file {{ ingress_tls_key }} -n {{ registry_namespace }}"
-    when: "ingress_secretName not in registry_secret_exists.stdout"
-
   - name: Registry | Deploy harbor chart
     helm_chart:
       name: "{{ helm_registry_chart_name }}"

--- a/kubernetes/ansible/playbooks/roles/registry_role/tasks/remove.yml
+++ b/kubernetes/ansible/playbooks/roles/registry_role/tasks/remove.yml
@@ -31,6 +31,7 @@
     set_fact:
       registry_role_templates:
         - { file: registry-namespace.yml }
+        - { file: registry-certificate.yml }
 
   - name: Registry | Create subfolder
     file:
@@ -45,15 +46,6 @@
     with_items: "{{ registry_role_templates }}"
     register: registry_role_manifests
 
-  - name: Registry | Check for secret
-    shell: "{{ bin_dir }}/kubectl get secrets -n {{ registry_namespace }}"
-    register: registry_secret_exists
-    changed_when: false
-
-  - name: Registry | Remove secret
-    shell: "{{ bin_dir }}/kubectl delete secret {{ ingress_secretName }} -n {{ registry_namespace }}"
-    when: "ingress_secretName in registry_secret_exists.stdout"
-
   # Namespace must be deployed before secret.
   - name: Registry | Remove manifests
     kube:
@@ -67,4 +59,3 @@
     file:
       path: "{{ role_dir }}"
       state: absent
-

--- a/kubernetes/ansible/playbooks/roles/registry_role/templates/registry-certificate.yml
+++ b/kubernetes/ansible/playbooks/roles/registry_role/templates/registry-certificate.yml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: registry-cert
+spec:
+  secretName: {{ ingress_secretName }}
+  issuerRef:
+    name: {{ grayskull_ca_issuer_name }}
+    kind: ClusterIssuer
+  dnsNames:
+    - registry.{{ grayskull_domain }}

--- a/kubernetes/ansible/playbooks/roles/rook_ceph_role/defaults/main.yml
+++ b/kubernetes/ansible/playbooks/roles/rook_ceph_role/defaults/main.yml
@@ -8,8 +8,12 @@ ceph_mon_count: 3
 ceph_objectstore_name: gsp-store
 ceph_data_dir: /storage/rook #/var/lib/rook
 
+prometheusOperator_enabled: true
+
 subfolder: "rook-ceph-role"
 role_dir: "{{ grayskull_dir }}/{{ subfolder }}"
+
+grayskull_ca_issuer_name: grayskull-ca-issuer
 
 helm_rook_ceph_chart_name: "{{ platform_prefix }}-rook-ceph"
 helm_rook_ceph_repo_url: https://charts.rook.io/release
@@ -22,7 +26,3 @@ template_ceph_image_version: v14.2.4-20191112
 ingress_url: "ceph.{{grayskull_domain}}"
 ingress_secretName: "ceph-gsp-tls" #TODO: make this into admin-gsp-tls
 ingress_path: "/"
-ingress_tls_cert: "{{ grayskull_dir }}/secrets/tls.crt"
-ingress_tls_key: "{{ grayskull_dir }}/secrets/tls.key"
-
-prometheusOperator_enabled: true

--- a/kubernetes/ansible/playbooks/roles/rook_ceph_role/tasks/install.yml
+++ b/kubernetes/ansible/playbooks/roles/rook_ceph_role/tasks/install.yml
@@ -12,6 +12,7 @@
       - { file: rook-ceph-prometheus-servicemonitor.yml }
       - { file: rook-ceph-prometheusrule.yml }
       - { file: rook-crd-clusterrole.yml }
+      - { file: rook-ceph-certificate.yml }
 
 - name: Rook Ceph | Create subfolder
   file:
@@ -23,6 +24,7 @@
   template:
     src: "rook-ceph-values.yml"
     dest: "{{ role_dir }}/rook-ceph-values.yml"
+
 
 - name: Rook Ceph | Create manifests
   template:
@@ -40,17 +42,6 @@
     resource: ns
     filename: "{{ role_dir }}/rook-ceph-namespace.yml"
     state: latest
-
-
-#---- Create secret
-- name: Rook Ceph | Check for secret
-  shell: "{{ bin_dir }}/kubectl get secrets -n {{ ceph_namespace }}"
-  register: rook_ceph_secret_exists
-  changed_when: false
-
-- name: Rook Ceph | Create secret
-  shell: "{{ bin_dir }}/kubectl create secret generic {{ ingress_secretName }} --from-file {{ ingress_tls_cert }} --from-file {{ ingress_tls_key }} -n {{ ceph_namespace }}"
-  when: "ingress_secretName not in rook_ceph_secret_exists.stdout"
 
 - name: Rook Ceph | Deploy chart
   helm_chart:

--- a/kubernetes/ansible/playbooks/roles/rook_ceph_role/tasks/remove.yml
+++ b/kubernetes/ansible/playbooks/roles/rook_ceph_role/tasks/remove.yml
@@ -16,6 +16,7 @@
         - { file: rook-ceph-prometheus-servicemonitor.yml }
         - { file: rook-ceph-prometheusrule.yml }
         - { file: rook-crd-clusterrole.yml }
+        - { file: rook-ceph-certificate.yml }
 
   - name: Rook Ceph | Create subfolder
     file:
@@ -64,20 +65,6 @@
       filename: "{{ role_dir }}/{{ item.item.file }}"
       state: absent
     with_items: "{{ rook_ceph_role_manifests.results }}"
-
-  #---- Create secret
-  - name: Rook Ceph | Check for secret
-    shell: "{{ bin_dir }}/kubectl get secrets -n {{ ceph_namespace }}"
-    register: rook_ceph_secret_exists
-    changed_when: false
-
-  - name: Rook Ceph | Remove secret
-    shell: "{{ bin_dir }}/kubectl delete secret {{ ingress_secretName }} -n {{ ceph_namespace }}"
-    when: 
-      - "ingress_secretName in rook_ceph_secret_exists.stdout"
-
-
-  #---- Delete namespace and role folder
 
   - name: Rook Ceph | Delete namespace
     kube:

--- a/kubernetes/ansible/playbooks/roles/rook_ceph_role/templates/rook-ceph-certificate.yml
+++ b/kubernetes/ansible/playbooks/roles/rook_ceph_role/templates/rook-ceph-certificate.yml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: dash-cert
+spec:
+  secretName: {{ ingress_secretName }}
+  issuerRef:
+    name: {{ grayskull_ca_issuer_name }}
+    kind: ClusterIssuer
+  dnsNames:
+    - ceph.{{ grayskull_domain }}


### PR DESCRIPTION
This PR closes #72 by adding cert-manager to manage certificates. It removes the existing certificates task and creates cluster issuer resources to create secrets in namespaces where certificate resources are present.