### PR TITLE
add network load balancer in front of cluster

### DIFF
--- a/kubernetes/terraform/loadbalancer/eip.tf
+++ b/kubernetes/terraform/loadbalancer/eip.tf
@@ -1,0 +1,8 @@
+resource "aws_eip" "k8s_eip" {
+  vpc              = true
+
+  tags = {
+    Name = "${terraform.workspace}_${var.name}_listener"
+    Environment = terraform.workspace
+  }
+}

--- a/kubernetes/terraform/loadbalancer/loadbalancer.tf
+++ b/kubernetes/terraform/loadbalancer/loadbalancer.tf
@@ -1,0 +1,41 @@
+resource "aws_lb" "k8s_lb" {
+  name               = "${terraform.workspace}-${var.name}-lb"
+  internal           = false
+  load_balancer_type = "network"
+  
+  subnet_mapping {
+    subnet_id        = var.subnets[0].id
+    allocation_id    = aws_eip.k8s_eip.id
+  }
+
+  enable_deletion_protection = false
+
+  tags = {
+    Name = "${terraform.workspace}_${var.name}_loadbalancer"
+    Environment = terraform.workspace
+  }
+}
+
+resource "aws_lb_listener" "k8s_lb_listener_80" {
+  load_balancer_arn  = aws_lb.k8s_lb.arn
+  port               = "80"
+  protocol           = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.k8s_target_group.arn
+  }
+
+}
+
+resource "aws_lb_listener" "k8s_lb_listener_443" {
+  load_balancer_arn  = aws_lb.k8s_lb.arn
+  port               = "443"
+  protocol           = "TCP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.k8s_target_group.arn
+  }
+
+}

--- a/kubernetes/terraform/loadbalancer/target_group.tf
+++ b/kubernetes/terraform/loadbalancer/target_group.tf
@@ -1,0 +1,27 @@
+resource "aws_lb_target_group" "k8s_target_group" {
+  name     = "tf-example-lb-tg"
+  port     = 80
+  protocol = "TCP"
+  vpc_id   = var.vpc.id
+
+  tags = {
+    Name = "${terraform.workspace}_${var.name}_listener"
+    Environment = terraform.workspace
+  }
+}
+
+resource "aws_lb_target_group_attachment" "k8s_target_group_assoc_80" {
+  count            = length(var.nodes)
+
+  target_group_arn = aws_lb_target_group.k8s_target_group.arn
+  target_id        = var.nodes[count.index].id
+  port             = 80
+}
+
+resource "aws_lb_target_group_attachment" "k8s_target_group_assoc_443" {
+  count            = length(var.nodes)
+
+  target_group_arn = aws_lb_target_group.k8s_target_group.arn
+  target_id        = var.nodes[count.index].id
+  port             = 443
+}

--- a/kubernetes/terraform/loadbalancer/variables.tf
+++ b/kubernetes/terraform/loadbalancer/variables.tf
@@ -1,0 +1,19 @@
+variable "name" {
+  type        = string
+  description = "Name to prefix in EC2 dashboard"
+} 
+
+variable "subnets" {
+  type        = list
+  description = "subnet to attach to load balancer"
+}
+
+variable "vpc" {
+#  type        = string
+  description = "vpc to attach to load balancer"
+}
+
+variable "nodes" {
+  type        = list
+  description = "nodes to attach to load balancer"
+}

--- a/kubernetes/terraform/main.tf
+++ b/kubernetes/terraform/main.tf
@@ -41,4 +41,12 @@ module "k8s_network" {
   nodes = concat(module.master.nodes, module.worker.nodes)
 }
 
+module "k8s_loadbalancer" {
+  source = "./loadbalancer"
+  name = var.lb_name
+  subnets = module.k8s_network.subnets
+  vpc = module.k8s_network.vpc
+  nodes = concat(module.master.nodes, module.worker.nodes)
+}
+
 #TODO include commented out templates for other possible node types, like masters that are also workers.

--- a/kubernetes/terraform/network/outputs.tf
+++ b/kubernetes/terraform/network/outputs.tf
@@ -5,3 +5,7 @@ output "security_groups" {
 output "subnets" {
 	value = [aws_subnet.subnet_1, aws_subnet.subnet_2, aws_subnet.subnet_3]
 }
+
+output "vpc" {
+	value = aws_vpc.vpc
+}

--- a/kubernetes/terraform/variables.tf
+++ b/kubernetes/terraform/variables.tf
@@ -73,3 +73,10 @@ variable "public_dns" {
   description = "Whether the nodes should be given public IPs."
 }
 
+#---- Loadbalancer
+
+variable "lb_name" {
+  type        = string
+  default     = "k8s-lb"
+  description = "Name to add to all the lb resources"
+}


### PR DESCRIPTION
 Closes #74 

This PR adds a network loadbalancer in front of the nodes. This will allow the ingress to properly load balance by utilizing connections into multiple nodes. It also creates one outward facing IP for connecting normal traffic to, which allows transparently hiding the ips of the nodes.