### PR TITLE
Add packer contents to generate AMI

### DIFF
--- a/kubernetes/terraform/k8s_node/user_data.sh
+++ b/kubernetes/terraform/k8s_node/user_data.sh
@@ -29,36 +29,19 @@ sudo pvcreate /dev/nvme0n1p3
 sudo vgextend VolGroup00 /dev/nvme0n1p3
 sudo lvextend -l +100%FREE /dev/mapper/VolGroup00-rootVol
 sudo resize2fs /dev/mapper/VolGroup00-rootVol
-sudo yum install -y python2
 
 # TODO Replace this with an ami that comes with docker installed
 sudo touch /1.txt
 
 #--- Install docker, add the user to the group, and start docker
-#sudo yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
-#sudo yum install -y docker-ce-18.06.3.ce-3.el7
-sudo yum install docker -y
 sudo touch /2.txt
-#sudo chkconfig docker on
-#sudo sed -i -e 's/slave/shared/g' /lib/systemd/system/docker.service
-#sudo systemctl daemon-reload
-sudo systemctl enable docker
-sudo service docker start
-#from std image
-sudo groupadd docker
-sudo usermod -aG docker maintuser
-#sudo chgrp docker /lib/systemd/system/docker.socket
-#sudo chmod g+w /lib/systemd/system/docker.socket
 
 #--- Relocate where docker stores images for more room
 sudo touch /3.txt
-#TODO: CURRENTLY TESTING THIS
 sudo mkdir -p /storage/docker
 sudo service docker stop
 sudo mv /var/lib/docker /storage/
 ln -s /storage/docker /var/lib/docker
-
-# END TODO
 
 # Disable the firewall initially. This should be enabled and configured later by ansible
 sudo systemctl disable firewalld

--- a/kubernetes/terraform/k8s_node/variables.tf
+++ b/kubernetes/terraform/k8s_node/variables.tf
@@ -6,7 +6,7 @@ variable "k8s_root_size" {
 
 variable "k8s_ami" {
   type        = string
-  default     = "ami-06432267"
+  default     = "ami-54301135"
   description = "AMI to use for the k8s nodes"
 }
 

--- a/packer/kube-base.json
+++ b/packer/kube-base.json
@@ -1,0 +1,22 @@
+{
+  "builders": [
+    {
+      "type": "amazon-ebs",
+      "region": "us-gov-west-1",
+      "source_ami": "ami-06432267",
+      "instance_type": "t2.micro",
+      "ssh_username": "maintuser",
+      "ami_name": "kube-base {{timestamp}}",
+      "associate_public_ip_address": true,
+      "vpc_id": "",
+      "subnet_id": ""
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "script": "user_data.sh"
+    }
+  ]
+}

--- a/packer/user_data.sh
+++ b/packer/user_data.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# This script does some basic tasks necessary to bootstrap hosts for use by kubespray later
+
+sudo yum install -y python2 docker
+
+# TODO Replace this with an ami that comes with docker installed
+sudo touch /1.txt
+
+#--- Install docker, add the user to the group, and start docker
+sudo touch /2.txt
+sudo systemctl enable docker
+sudo service docker start
+#from std image
+sudo groupadd docker
+sudo usermod -aG docker maintuser


### PR DESCRIPTION
 Closes #67 

This pr adds the the contents of packer for generating an ami. This AMI will use the old one as a base but will preinstall docker and python. This should save some time on the user data script. Though testing it shows not as much as expected. The userdata that runs on nodes when terraform deploys seems to take a strangely long time to create file.

TODO: add readme