### PR TITLE
Disable metricbeat

### DIFF
--- a/kubernetes/ansible/playbooks/roles/elk_role/defaults/main.yml
+++ b/kubernetes/ansible/playbooks/roles/elk_role/defaults/main.yml
@@ -20,9 +20,9 @@ helm_logstash_chart_name: "{{ platform_prefix }}-logstash"
 helm_logstash_repo_url: https://helm.elastic.co
 helm_logstash_image_name: logstash
 helm_logstash_chart_version: 7.5.2
-helm_metricbeat_chart_name: "{{ platform_prefix }}-metricbeat"
-helm_metricbeat_repo_url: https://helm.elastic.co
-helm_metricbeat_image_name: metricbeat
-helm_metricbeat_chart_version: 7.5.2
+# helm_metricbeat_chart_name: "{{ platform_prefix }}-metricbeat"
+# helm_metricbeat_repo_url: https://helm.elastic.co
+# helm_metricbeat_image_name: metricbeat
+# helm_metricbeat_chart_version: 7.5.2
 
 ingress_secretName: "elk-gsp-tls"

--- a/kubernetes/ansible/playbooks/roles/elk_role/tasks/download.yml
+++ b/kubernetes/ansible/playbooks/roles/elk_role/tasks/download.yml
@@ -23,10 +23,10 @@
     --untar \
     {{ helm_logstash_image_name }}"
 
-- name: ELK | Download Metricbeat chart
-  shell: "{{ bin_dir }}/helm fetch \
-    --repo {{ helm_metricbeat_repo_url }} \
-    --version {{ helm_metricbeat_chart_version }} \
-    --destination {{ grayskull_dir }} \
-    --untar \
-    {{ helm_metricbeat_image_name }}"
+# - name: ELK | Download Metricbeat chart
+#   shell: "{{ bin_dir }}/helm fetch \
+#     --repo {{ helm_metricbeat_repo_url }} \
+#     --version {{ helm_metricbeat_chart_version }} \
+#     --destination {{ grayskull_dir }} \
+#     --untar \
+#     {{ helm_metricbeat_image_name }}"

--- a/kubernetes/ansible/playbooks/roles/elk_role/tasks/install.yml
+++ b/kubernetes/ansible/playbooks/roles/elk_role/tasks/install.yml
@@ -10,7 +10,7 @@
       - { file: elasticsearch-values.yml }
       - { file: kibana-values.yml }
       - { file: logstash-values.yml }
-      - { file: metricbeat-values.yml }
+      # - { file: metricbeat-values.yml }
 
 - name: ELK | Template Values
   template:
@@ -68,11 +68,11 @@
     chart_version: "{{ helm_logstash_chart_version }}"
     path_to_values: "{{ role_dir }}/logstash-values.yml"
 
-- name: ELK | Deploy Metricbeat chart
-  helm_chart:
-    name: "{{ helm_metricbeat_chart_name }}"
-    namespace: "{{ elk_namespace }}"
-    bin_dir: "{{ bin_dir }}"
-    chart_src: "{{ grayskull_dir }}/{{ helm_metricbeat_image_name }}"
-    chart_version: "{{ helm_metricbeat_chart_version }}"
-    path_to_values: "{{ role_dir }}/metricbeat-values.yml"
+# - name: ELK | Deploy Metricbeat chart
+#   helm_chart:
+#     name: "{{ helm_metricbeat_chart_name }}"
+#     namespace: "{{ elk_namespace }}"
+#     bin_dir: "{{ bin_dir }}"
+#     chart_src: "{{ grayskull_dir }}/{{ helm_metricbeat_image_name }}"
+#     chart_version: "{{ helm_metricbeat_chart_version }}"
+#     path_to_values: "{{ role_dir }}/metricbeat-values.yml"

--- a/kubernetes/ansible/playbooks/roles/elk_role/tasks/remove.yml
+++ b/kubernetes/ansible/playbooks/roles/elk_role/tasks/remove.yml
@@ -32,14 +32,14 @@
     chart_version: "{{ helm_logstash_chart_version }}"
     state: absent
 
-- name: ELK | Remove Metricbeat chart
-  helm_chart:
-    name: "{{ helm_metricbeat_chart_name }}"
-    namespace: "{{ elk_namespace }}"
-    bin_dir: "{{ bin_dir }}"
-    chart_src: "{{ grayskull_dir }}/{{ helm_metricbeat_image_name }}"
-    chart_version: "{{ helm_metricbeat_chart_version }}"
-    state: absent
+# - name: ELK | Remove Metricbeat chart
+#   helm_chart:
+#     name: "{{ helm_metricbeat_chart_name }}"
+#     namespace: "{{ elk_namespace }}"
+#     bin_dir: "{{ bin_dir }}"
+#     chart_src: "{{ grayskull_dir }}/{{ helm_metricbeat_image_name }}"
+#     chart_version: "{{ helm_metricbeat_chart_version }}"
+#     state: absent
 
 #---- Copy over the templates to be used with kubectl delete -f. 
 - name: ELK | Templates list

--- a/kubernetes/ansible/playbooks/roles/registry_role/templates/registry-values.yml
+++ b/kubernetes/ansible/playbooks/roles/registry_role/templates/registry-values.yml
@@ -29,6 +29,11 @@ secretKey: "{{ hostvars[groups['kube-setup-delegate'][0]]['harbor_key'] }}"
 persistence:
   enabled: true
   resourcePolicy: ""
+  persistentVolumeClaim:
+    registry:
+      size: 30Gi
+    database:
+      size: 20Gi
 
 logLevel: info
 


### PR DESCRIPTION
Metricbeat was pulled into the elk role, however it has proven unstable, resource intensive, and also partially superfluous with prometheus. 

This change simply comments out the resources to not be used. A future pr may remove them completely. 

Also this pr increases the default size of the registry volume, since we found our dev registry to fill up quickly.