### PR TITLE
add useful rook manifests for object storage

### DIFF
--- a/kubernetes/ansible/playbooks/roles/rook_ceph_role/templates/rook-ceph-values.yml
+++ b/kubernetes/ansible/playbooks/roles/rook_ceph_role/templates/rook-ceph-values.yml
@@ -14,20 +14,6 @@ csi:
   enableCephfsDriver: true
   enableRbdDriver: true
   forceCephFSKernelClient: false
-  # provisionerTolerations:
-  #   - key: "node-role.kubernetes.io/controlplane"
-  #     operator: "Exists"
-  #     effect: NoSchedule
-  #   - key: "node-role.kubernetes.io/etcd"
-  #     operator: "Exists"
-  #     effect: NoExecute
-  # pluginTolerations:
-  #   - key: "node-role.kubernetes.io/controlplane"
-  #     operator: "Exists"
-  #     effect: NoSchedule
-  #   - key: "node-role.kubernetes.io/etcd"
-  #     operator: "Exists"
-  #     effect: NoExecute
 
 hostpathRequiresPrivileged: true
 

--- a/kubernetes/manifests/rook/ceph-object-bucket-claim.yml
+++ b/kubernetes/manifests/rook/ceph-object-bucket-claim.yml
@@ -1,0 +1,7 @@
+apiVersion: objectbucket.io/v1alpha1
+kind: ObjectBucketClaim
+metadata:
+  name: ion-store-bucket-claim
+spec:
+  generateBucketName: ion-store-bucket
+  storageClassName: gsp-bucket

--- a/kubernetes/manifests/rook/ceph-object-sc.yml
+++ b/kubernetes/manifests/rook/ceph-object-sc.yml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+   name: stg-bucket
+provisioner: ceph.rook.io/bucket
+reclaimPolicy: Delete
+parameters:
+  objectStoreName: gsp-store
+  objectStoreNamespace: grayskull-storage

--- a/kubernetes/manifests/rook/ceph-object-store.yml
+++ b/kubernetes/manifests/rook/ceph-object-store.yml
@@ -1,0 +1,22 @@
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStore
+metadata:
+  name: gsp-store
+  namespace: grayskull-storage
+spec:
+  metadataPool:
+    failureDomain: host
+    replicated:
+      size: 3
+  dataPool:
+    failureDomain: host
+    erasureCoded:
+      dataChunks: 2
+      codingChunks: 1
+  preservePoolsOnDelete: true
+  gateway:
+    type: s3
+    sslCertificateRef:
+    port: 80
+    securePort:
+    instances: 1

--- a/kubernetes/manifests/rook/ceph-object-user.yml
+++ b/kubernetes/manifests/rook/ceph-object-user.yml
@@ -1,0 +1,7 @@
+apiVersion: ceph.rook.io/v1
+kind: CephObjectStoreUser
+metadata:
+  name: s3-admin
+spec:
+  store: gsp-store
+  displayName: "gsp-store administrator"


### PR DESCRIPTION
This PR introduces some helpful manifests for working with object storage. Future work will involve automating object related ceph resources (such as #105), creating documentation on how to request a bucket, and how to consume its storage.  